### PR TITLE
Updated the color palette for the custom lightTheme

### DIFF
--- a/client/src/theme.js
+++ b/client/src/theme.js
@@ -2,6 +2,15 @@ import { createMuiTheme } from '@material-ui/core/styles';
 
 /** Light Theme */
 export const lightTheme = createMuiTheme({
+  overrides: {
+    MuiIconButton: {
+      root: {
+        '&:hover': {
+          backgroundColor: '$labelcolor'
+        }
+      }
+    }
+  },
   palette: {
     primary: {
       light: '#ffffff',

--- a/client/src/theme.js
+++ b/client/src/theme.js
@@ -1,49 +1,58 @@
 import { createMuiTheme } from '@material-ui/core/styles';
 
+/** Light Theme */
 export const lightTheme = createMuiTheme({
   palette: {
     primary: {
-      main: '#05386B',
+      light: '#ffffff',
+      main: '#f0f2f5',
+      dark: '#adafb3'
     },
     secondary: {
-      main: '#F6F6F6',
+      main: '#1878f2'
     },
+    info: {
+      main: '#3d3d3d'
+    },
+    error: {
+      main: '#f02849'
+    },
+    warning: {
+      main: '#000000'
+    },
+    success: {
+      main: '#31a24c'
+    }
   },
   MuiTypography: {
     variantMapping: {
-      body1: 'p',
-    },
-  },
+      body1: 'p'
+    }
+  }
 });
 //Headers
 lightTheme.typography.h1 = {
-  fontSize: 'calc(1rem + 5vmin)',
-  color: '#05386B'
+  fontSize: 'calc(1rem + 5vmin)'
 };
 lightTheme.typography.h2 = {
-  fontSize: 'calc(1rem + 4vmin)',
-  color: '#05386B'
+  fontSize: 'calc(1rem + 4vmin)'
 };
 lightTheme.typography.h3 = {
-  fontSize: 'calc(1rem + 3vmin)',
-  color: '#05386B'
+  fontSize: 'calc(1rem + 3vmin)'
 };
 lightTheme.typography.h4 = {
-  fontSize: 'calc(1rem + 2vmin)',
-  color: '#05386B'
+  fontSize: 'calc(1rem + 2vmin)'
 };
 lightTheme.typography.h5 = {
-  fontSize: 'calc(1rem + 1vmin)',
-  color: '#05386B'
+  fontSize: 'calc(1rem + 1vmin)'
 };
 
-//more typography 
+//more typography
 lightTheme.typography.subtitle1 = {
   fontSize: 'calc(1rem + 1vmin)',
   margin: '1rem .5rem',
-  fontWeight: 'normal',
-  color: '#313639'
-}
+  fontWeight: 'normal'
+};
 lightTheme.typography.body1 = {
-  fontSize: 'calc(.75rem + .5vmin)',
-}
+  fontSize: 'calc(.75rem + .5vmin)'
+};

--- a/client/src/theme.js
+++ b/client/src/theme.js
@@ -18,7 +18,9 @@ export const lightTheme = createMuiTheme({
       dark: '#adafb3'
     },
     secondary: {
-      main: '#1878f2'
+      light: '#AAC9FF',
+      main: '#1878f2',
+      dark: '#4267B2'
     },
     info: {
       main: '#3d3d3d'

--- a/client/src/theme.js
+++ b/client/src/theme.js
@@ -2,15 +2,6 @@ import { createMuiTheme } from '@material-ui/core/styles';
 
 /** Light Theme */
 export const lightTheme = createMuiTheme({
-  overrides: {
-    MuiIconButton: {
-      root: {
-        '&:hover': {
-          backgroundColor: '$labelcolor'
-        }
-      }
-    }
-  },
   palette: {
     primary: {
       light: '#ffffff',


### PR DESCRIPTION
Added colors to our custom MUI lightTheme in 'theme.js'. _Primary_, _secondary_, _info_, _error_, and _success_

Accessed as... _lightTheme.palette.primary.main_

_Primary_ contains 3 values: _light_, _main_ and _dark_. _Light_ will be the white color, and _main_ and _dark_ will be the two shades of grey

_Secondary_ just has one main value and will be the blue color

_Info_ has just one main value and will be the dark grey/black color(text input, user names, etc)

_Error_ has just one main value and will be the red color

_Success_ has just one main value and will be the green color