### PR TITLE
Created CircleImageWithTitleMolecule

### DIFF
--- a/client/src/components/Molecules/CircleImageWithTitle.js
+++ b/client/src/components/Molecules/CircleImageWithTitle.js
@@ -15,7 +15,7 @@ import { lightTheme } from '../../theme';
  */
 export default props => {
 	return (
-		<Grid container spacing={1}>
+		<Grid container spacing={1} alignItems="center">
 			<Grid item >
 				<CircleImage src={props.imageUrl} alt={props.imageAlt} clickAction={props.imageClick} />
 			</Grid>

--- a/client/src/components/Molecules/CircleImageWithTitle.js
+++ b/client/src/components/Molecules/CircleImageWithTitle.js
@@ -1,19 +1,28 @@
-import { } from '@material-ui/core';  
+import { Typography, Grid } from '@material-ui/core';
 import CircleImage from '../Atoms/CircleImage';
+import { lightTheme } from '../../theme';
 
 /**
  * Summary:
  * Circle image with a title to the right and subtitle below the title.
  * 
  * Props: 
- * image
- * title
- * subTitle
+ * imageUrl: string of url to image
+ * imageAlt: string of text for if image can not be loaded
+ * imageClick: function to run when image is clicked
+ * title: string for title
+ * subtitle: string for subtitle area.(is often time since last online)
  */
 export default props => {
 	return (
-		<div>
-			<p>Circle Image With Title</p>
-		</div>
+		<Grid container spacing={1}>
+			<Grid item >
+				<CircleImage src={props.imageUrl} alt={props.imageAlt} clickAction={props.imageClick} />
+			</Grid>
+			<Grid item>
+				<Typography variant="subtitle2">{props.title}</Typography>
+				<Typography style={{ color: lightTheme.palette.text.secondary }} variant="subtitle2">{props.subtitle}</Typography>
+			</Grid>
+		</Grid>
 	);
-}
+};


### PR DESCRIPTION
Made the CircleImageWithTitleMolecule using the CircleImage atom and material UI typography component. It can display the image, title, and a subtitle. Designed to be used at the top of post as a post header.